### PR TITLE
Introduce "blurhash"-like functionality using NextJS-builtin "placeholder" functionality.

### DIFF
--- a/blog/buildAssets.ts
+++ b/blog/buildAssets.ts
@@ -115,7 +115,6 @@ const getCoverImages = async () => {
                     format,
                     data,
                 });
-
                 foundImageFile = true;
                 break;
             } catch {
@@ -175,6 +174,15 @@ const handleCoverImages = async () => {
     for (const cover of covers) {
         result += `    '${cover.post}': {\n`;
 
+        const potatoImage = await sharp(cover.data)
+            .resize(64, 36)
+            .webp({
+                quality: 4,
+                effort: 6,
+                alphaQuality: 0,
+            })
+            .toBuffer();
+
         for (const settings of COVER_IMG_SETTINGS) {
             const { prefix, suffix, width, height, format } = settings;
 
@@ -194,6 +202,9 @@ const handleCoverImages = async () => {
                 format || 'webp'
             }') as Promise<{default: StaticImageData}>,\n`;
         }
+        result += `        'cover-potato': 'data:image/webp;base64,${potatoImage.toString(
+            'base64'
+        )}',\n`;
 
         result += '    },\n';
     }

--- a/blog/src/components/PostPreview.tsx
+++ b/blog/src/components/PostPreview.tsx
@@ -26,6 +26,10 @@ export const BlogPostPreview = async ({ post, variant }: Properties) => {
               })
         : undefined;
 
+    const potato = Object.keys(covers).includes(post.file)
+        ? covers[post.file as keyof typeof covers]['cover-potato']
+        : undefined;
+
     const { readingTime } = (await import(
         `../../../content/${post.file}/readme.mdx`
     )) as {
@@ -46,8 +50,12 @@ export const BlogPostPreview = async ({ post, variant }: Properties) => {
                 {cover ? (
                     <Image
                         src={cover}
+                        width={1200}
+                        height={600}
                         className="aspect-cover h-full w-full object-cover"
                         alt={post.title}
+                        placeholder="blur"
+                        blurDataURL={potato}
                     />
                 ) : (
                     <img
@@ -59,7 +67,7 @@ export const BlogPostPreview = async ({ post, variant }: Properties) => {
             </span>
             <span
                 className={clsx(
-                    'flex h-full flex-col gap-2 p-5 md:p-6 max-h-[200px] my-auto',
+                    'my-auto flex h-full max-h-[200px] flex-col gap-2 p-5 md:p-6',
                     variant == 'horizontal'
                         ? 'border-t md:border-none'
                         : 'border-t'


### PR DESCRIPTION
Make images blurry before loading on slow connections