### PR TITLE
Disable search indexing in deploy process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,10 +60,10 @@ jobs:
           SEARCH_JSON=$(cat blog/out/search.json)
           echo "::set-output name=search_json::${SEARCH_JSON}"
 
-      - name: Deploy search index
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: 'https://search.v3x.systems/indexes/ens-blog/documents?primaryKey=slug'
-          method: 'POST'
-          bearerToken: ${{ secrets.SEARCH_TOKEN }}
-          data: ${{ steps.read_search_json.outputs.search_json }}
+      # - name: Deploy search index
+      #   uses: fjogeleit/http-request-action@v1
+      #   with:
+      #     url: 'https://search.v3x.systems/indexes/ens-blog/documents?primaryKey=slug'
+      #     method: 'POST'
+      #     bearerToken: ${{ secrets.SEARCH_TOKEN }}
+      #     data: ${{ steps.read_search_json.outputs.search_json }}


### PR DESCRIPTION
Was getting the following build error, we can fix it later:

```
An error occurred trying to start process '/home/runner/runners/2.321.0/externals/node20/bin/node' with working directory '/home/runner/work/blog/blog'. Argument list too long
```