### PR TITLE
Deprecate repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]  
+> This repo is deprecated. The ENS blog has moved to [ensdomains/ensdomains-landing](https://github.com/ensdomains/ensdomains-landing).
+
 [![readme](./.github/readme.png)](https://alpha-docs.ens.domains/?ref=github-banner)
 
 The Ethereum Name Service (ENS) is a distributed, open, and extensible naming system based on the Ethereum blockchain.


### PR DESCRIPTION
Now that the blog lives in [ensdomains/ensdomains-landing](https://github.com/ensdomains/ensdomains-landing/), we should update the readme and archive this repo.